### PR TITLE
fixing elastic search example

### DIFF
--- a/elasticsearch-deployment/Vagrantfile
+++ b/elasticsearch-deployment/Vagrantfile
@@ -4,10 +4,6 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
 
-  config.vm.provider "virtualbox" do |v|
-    v.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
-  end
-
   config.vm.define "elastic-1" do |node|
       node.vm.network "private_network", ip: "192.168.55.11"
       node.vm.provider :virtualbox do |vb|

--- a/elasticsearch-deployment/provision.groovy
+++ b/elasticsearch-deployment/provision.groovy
@@ -1,10 +1,10 @@
 def keypath(def machine) { ".vagrant/machines/$machine/virtualbox/private_key" }
 
 inlineInventory {
-  node id: 'elastic-1', host: '192.168.55.11', username: 'ubuntu', keyfile: keypath('elastic-1')
-  node id: 'elastic-2', host: '192.168.55.12', username: 'ubuntu', keyfile: keypath('elastic-2')
-  node id: 'elastic-3', host: '192.168.55.13', username: 'ubuntu', keyfile: keypath('elastic-3')
-  node id: 'elastic-4', host: '192.168.55.14', username: 'ubuntu', keyfile: keypath('elastic-4')
+  node id: 'elastic-1', host: '192.168.55.11', username: 'vagrant', keyfile: keypath('elastic-1')
+  node id: 'elastic-2', host: '192.168.55.12', username: 'vagrant', keyfile: keypath('elastic-2')
+  node id: 'elastic-3', host: '192.168.55.13', username: 'vagrant', keyfile: keypath('elastic-3')
+  node id: 'elastic-4', host: '192.168.55.14', username: 'vagrant', keyfile: keypath('elastic-4')
 }.provision {
 
     task name: "install docker", parallel: 4, actions: {
@@ -17,12 +17,12 @@ inlineInventory {
     }
 
     task name: "run elasticsearch nodes", actions: {
-      shell """
+      shell user: 'root', command: """
         docker run -d -p 9200:9200 -p 9300:9300 \
         -e "node.name=${node.id}" \
         -e "node.master=true" \
         -e "network.publish_host=${node.host}" \
-        -e "discovery.zen.ping.unicast.hosts=${nodes*.host.join(',')}" \
+        -e "discovery.zen.ping.unicast.hosts=${inventory.nodes*.value.host.join(',')}" \
         -e "ES_JAVA_OPTS=-Xmx1024m -Xms1024m" \
         docker.elastic.co/elasticsearch/elasticsearch:5.6.3
       """


### PR DESCRIPTION
I had to make these changes in order to run the elasticsearch example.

My environment:
Infrastructor 0.2.2
Vagrant 2.2.4
VirtualBox Version 6.0.4 r128413 (Qt5.6.3)
macOS High Sierra 10.13.6

Hope this helps!